### PR TITLE
Sane Return Values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pyc
 *.egg-info/
 *.xml
+build/
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ script:
   - make test-unit
   - docker-compose up -d
   - sleep 5
-  - python bin/funcy-task-engine.py xmltest -t tests/funcy/envvar-uuid-nsq-postgres.yml
+  - python bin/funcy-task-engine.py xmltest -t tests/funcy/uuid-nsq-postgres.yml

--- a/funcytaskengine/engine.py
+++ b/funcytaskengine/engine.py
@@ -81,8 +81,6 @@ class TaskEngine(object):
 
                     self.machine.run_current_event(event_result_q=self.event_result_q)
 
-                # gevent.sleep(settings.ENGINE_LOOP_INTERVAL)
-
         except Timeout:
             logger.error('%s', {
                 'message': 'task timeout reached',

--- a/funcytaskengine/engine.py
+++ b/funcytaskengine/engine.py
@@ -53,7 +53,7 @@ class TaskEngine(object):
                 try:
                     # we can ignore the next state, this is only used to indicate
                     # when it's time to apply a transition
-                    result = self.event_result_q.get(block=False)
+                    result = self.event_result_q.get()
 
                 except gevent.queue.Empty:
                     logger.debug('%s', {
@@ -81,7 +81,7 @@ class TaskEngine(object):
 
                     self.machine.run_current_event(event_result_q=self.event_result_q)
 
-                gevent.sleep(settings.ENGINE_LOOP_INTERVAL)
+                # gevent.sleep(settings.ENGINE_LOOP_INTERVAL)
 
         except Timeout:
             logger.error('%s', {

--- a/funcytaskengine/event_fulfillment/base.py
+++ b/funcytaskengine/event_fulfillment/base.py
@@ -8,5 +8,5 @@ class BaseFulfillment(object):
         pass
 
     @abstractmethod
-    def run(self, initiator, conditions):
+    def run(self, initiator, conditions, **kwargs):
         pass

--- a/funcytaskengine/event_fulfillment/noop.py
+++ b/funcytaskengine/event_fulfillment/noop.py
@@ -3,5 +3,5 @@ from .base import BaseFulfillment
 
 class SingleFireFulfillment(BaseFulfillment):
 
-    def run(self, initiator, conditions):
+    def run(self, initiator, conditions, **kwargs):
         return conditions.are_met(initiator.execute())

--- a/funcytaskengine/event_fulfillment/noop.py
+++ b/funcytaskengine/event_fulfillment/noop.py
@@ -1,7 +1,25 @@
+import logging
+
+from funcytaskengine.event_fulfillment.return_values import EventFailureResult
+from funcytaskengine.event_fulfillment.return_values import EventSuccessDecoratorResult
 from .base import BaseFulfillment
+
+
+logger = logging.getLogger(__name__)
 
 
 class SingleFireFulfillment(BaseFulfillment):
 
     def run(self, initiator, conditions, **kwargs):
-        return conditions.are_met(initiator.execute())
+        logger.debug({
+            'initiator': initiator,
+            'conditions': conditions,
+        })
+
+        initiator_result = initiator.execute()
+        conditions.initialize(initiator_result)
+
+        if conditions.are_met():
+            return EventSuccessDecoratorResult(conditions.values())
+
+        return EventFailureResult()

--- a/funcytaskengine/event_fulfillment/nsq.py
+++ b/funcytaskengine/event_fulfillment/nsq.py
@@ -32,3 +32,34 @@ class NSQStreamingFulfillment(BaseFulfillment):
                 _r.close()
 
         reader.start()
+
+
+class NSQStreamingSingleMessageFulfillment(BaseFulfillment):
+
+    def __init__(self, type, topic, channel, address):
+        self.topic = topic
+        self.channel = channel
+        self.address = address
+
+    def run(self, initiator, conditions, **kwargs):
+        """
+        Connects to NSQd instance specified by address, and evaluates
+        the conditions on the first message received.
+
+        :param initiator:
+        :param conditions:
+        :return:
+        """
+        # user can still initiate
+        initiator.execute()
+
+        reader = gnsq.Reader(self.topic, self.channel, self.address)
+
+        @reader.on_message.connect
+        def handler(_r, message):
+            message.finish()
+            _r.close()
+            _r.funcy_message = message
+
+        reader.start()
+        return conditions.are_met(reader.funcy_message)

--- a/funcytaskengine/event_fulfillment/nsq.py
+++ b/funcytaskengine/event_fulfillment/nsq.py
@@ -9,7 +9,7 @@ class NSQStreamingFulfillment(BaseFulfillment):
         self.channel = channel
         self.address = address
 
-    def run(self, initiator, conditions):
+    def run(self, initiator, conditions, **kwargs):
         """
         Connects to NSQd instance specified by address, and evaluates
         the conditions against every message received.

--- a/funcytaskengine/event_fulfillment/poll.py
+++ b/funcytaskengine/event_fulfillment/poll.py
@@ -13,7 +13,7 @@ class PollerFulfillment(BaseFulfillment):
         self.running = False
         self.interval = 1000 / frequency_ms
 
-    def run(self, initiator, conditions):
+    def run(self, initiator, conditions, **kwargs):
         """
         Decorates an initiator function and runs it in a loop?
 

--- a/funcytaskengine/event_fulfillment/results.py
+++ b/funcytaskengine/event_fulfillment/results.py
@@ -7,7 +7,9 @@ class FromEventNameFulfillment(BaseFulfillment):
         self.event_name = event_name
 
     def run(self, initiator, conditions, **kwargs):
+        return_value = kwargs['events'].return_value(self.event_name)
+        import ipdb; ipdb.set_trace();
         print('HEEEEEEEEEEEEEEEEEEEEERE')
         print(kwargs)
-        conditions.are_met()
+        conditions.are_met(return_value)
 

--- a/funcytaskengine/event_fulfillment/results.py
+++ b/funcytaskengine/event_fulfillment/results.py
@@ -1,4 +1,9 @@
 from funcytaskengine.event_fulfillment.base import BaseFulfillment
+from funcytaskengine.event_fulfillment.return_values import EventSuccessDecoratorResult, EventFailureResult
+
+
+def extract_fn(values):
+    return values[0]
 
 
 class FromEventNameFulfillment(BaseFulfillment):
@@ -6,10 +11,14 @@ class FromEventNameFulfillment(BaseFulfillment):
     def __init__(self, type, event_name):
         self.event_name = event_name
 
-    def run(self, initiator, conditions, **kwargs):
-        return_value = kwargs['events'].return_value(self.event_name)
-        import ipdb; ipdb.set_trace();
-        print('HEEEEEEEEEEEEEEEEEEEEERE')
-        print(kwargs)
-        conditions.are_met(return_value)
+    def run(self, initiator, conditions, event_results, **kwargs):
+        result = event_results.return_value_from_name(self.event_name)
+        i = extract_fn(result.values())
+
+        conditions.initialize(i)
+
+        if conditions.are_met():
+            return EventSuccessDecoratorResult(i)
+
+        return EventFailureResult()
 

--- a/funcytaskengine/event_fulfillment/results.py
+++ b/funcytaskengine/event_fulfillment/results.py
@@ -1,0 +1,13 @@
+from funcytaskengine.event_fulfillment.base import BaseFulfillment
+
+
+class FromEventNameFulfillment(BaseFulfillment):
+
+    def __init__(self, type, event_name):
+        self.event_name = event_name
+
+    def run(self, initiator, conditions, **kwargs):
+        print('HEEEEEEEEEEEEEEEEEEEEERE')
+        print(kwargs)
+        conditions.are_met()
+

--- a/funcytaskengine/event_fulfillment/return_values.py
+++ b/funcytaskengine/event_fulfillment/return_values.py
@@ -1,0 +1,47 @@
+from abc import ABCMeta, abstractmethod
+
+
+class EventResults(object):
+    def __init__(self):
+        self.by_event_name = {}
+        self.in_order = []
+
+    def add(self, return_value):
+        self.in_order.append(return_value)
+        self.by_event_name[return_value.event_name] = return_value
+
+    def return_value_from_name(self, event_name):
+        return self.by_event_name[event_name]
+
+
+class EventResult(object):
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def success(self):
+        pass
+
+    @abstractmethod
+    def values(self):
+        pass
+
+
+class EventSuccessDecoratorResult(EventResult):
+
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+
+    def success(self):
+        return True
+
+    def values(self):
+        return self.wrapped.values()
+
+
+class EventFailureResult(EventResult):
+
+    def success(self):
+        return False
+
+    def values(self):
+        return []

--- a/funcytaskengine/initiators/nsq.py
+++ b/funcytaskengine/initiators/nsq.py
@@ -3,6 +3,7 @@ import json
 import gnsq
 import logging
 
+from funcytaskengine.event_fulfillment.return_values import EventSuccessDecoratorResult
 from .base import BaseInitiator
 
 
@@ -21,10 +22,15 @@ class NSQPublisherInitiator(BaseInitiator):
 
     def execute(self):
         logger.debug('%s', {
-            'message': 'publishing_message_nsq'
+            'message': 'publishing_message_nsq',
+            'body': self.message,
         })
-        gnsq.Nsqd(address=self.nsqd_address).publish(
-            self.topic,
-            json.dumps(self.message)
+
+        return EventSuccessDecoratorResult(
+            gnsq.Nsqd(address=self.nsqd_address).publish(
+                self.topic,
+                json.dumps(self.message)
+            )
         )
+
 

--- a/funcytaskengine/machine.py
+++ b/funcytaskengine/machine.py
@@ -66,6 +66,9 @@ class Events(object):
     def teardown_current(self):
         pass
 
+    def return_value(self, event_name):
+        return self.event_return_values[event_name]
+
     def run(self, event_name, event_result_q):
         # TODO per event timeout
         # get the current event,
@@ -75,7 +78,7 @@ class Events(object):
 
         try:
             self.event_return_values[event_name] = event.execute(
-                event_return_values=self.event_return_values
+                events=self
             )
         except (Exception, Timeout) as e:
             logger.error('%s', {

--- a/funcytaskengine/transition_conditions/__init__.py
+++ b/funcytaskengine/transition_conditions/__init__.py
@@ -11,13 +11,29 @@ class TransitionConditions(object):
         self.conditions = [
             TransitionConditionFactory.build(cc) for cc in config_conditions
         ]
+        self.intialized = False
+        self.vs = None
 
-    def are_met(self, initiator_result):
+    def initialize(self, vs):
+        self.initialized = True
+        self.vs = vs
+
+    def values(self):
+        return self.vs
+
+    def are_met(self):
         """
-        Checks to see if all the conditions have been met.
+        Checks to see if all the conditions have been met, against the values.
 
-        :param initiator_result:
+        Mutates the values with the return value of each condition being applied.
+        Allows for a transformation, so that the values can be used for other
+        event states.
+
         :return: boolean
         """
-        return all([con.is_met(initiator_result) for con in self.conditions])
+        assert self.initialized
 
+        for con in self.conditions:
+            self.vs = con.is_met(self.vs)
+
+        return bool(self.vs)

--- a/funcytaskengine/transition_conditions/__init__.py
+++ b/funcytaskengine/transition_conditions/__init__.py
@@ -19,5 +19,5 @@ class TransitionConditions(object):
         :param initiator_result:
         :return: boolean
         """
-        return all(con.is_met(initiator_result) for con in self.conditions)
+        return [con.is_met(initiator_result) for con in self.conditions]
 

--- a/funcytaskengine/transition_conditions/__init__.py
+++ b/funcytaskengine/transition_conditions/__init__.py
@@ -19,5 +19,5 @@ class TransitionConditions(object):
         :param initiator_result:
         :return: boolean
         """
-        return [con.is_met(initiator_result) for con in self.conditions]
+        return all([con.is_met(initiator_result) for con in self.conditions])
 

--- a/funcytaskengine/transition_conditions/assertions.py
+++ b/funcytaskengine/transition_conditions/assertions.py
@@ -1,6 +1,11 @@
 import json
 
+import logging
+
 from .base import BaseTransitionCondition
+
+
+logger = logging.getLogger(__name__)
 
 
 class LengthEqual(BaseTransitionCondition):
@@ -16,5 +21,30 @@ class LengthEqual(BaseTransitionCondition):
 
 class ParseJSON(BaseTransitionCondition):
 
+    def __init__(self, type, value_property=None):
+        self.value_property = value_property
+
     def is_met(self, value):
-        return json.loads(value)
+        to_load = value
+        if self.value_property:
+            to_load = getattr(value, self.value_property)
+        return json.loads(to_load)
+
+
+class HasKeys(BaseTransitionCondition):
+
+    def __init__(self, type, value_property=None, keys=()):
+        self.keys = keys
+        self.value_property = value_property
+
+    def is_met(self, value):
+        to_assert = value
+        if self.value_property:
+            to_assert = getattr(value, self.value_property)
+
+        logger.info({
+            'to_assert': to_assert,
+            'keys': self.keys,
+        })
+        assert set(to_assert) == set(self.keys)
+        return to_assert

--- a/funcytaskengine/transition_conditions/assertions.py
+++ b/funcytaskengine/transition_conditions/assertions.py
@@ -1,3 +1,5 @@
+import json
+
 from .base import BaseTransitionCondition
 
 
@@ -10,3 +12,9 @@ class LengthEqual(BaseTransitionCondition):
         assert len(collection) == self.length, 'collection ({}) != expected ({})'.format(
             len(collection), self.length
         )
+
+
+class ParseJSON(BaseTransitionCondition):
+
+    def is_met(self, value):
+        return json.loads(value)

--- a/funcytaskengine/transition_conditions/noop.py
+++ b/funcytaskengine/transition_conditions/noop.py
@@ -3,5 +3,5 @@ from .base import BaseTransitionCondition
 
 class NoopCondition(BaseTransitionCondition):
 
-    def is_met(self, *args, **kwargs):
-        return True
+    def is_met(self, values, *args, **kwargs):
+        return values

--- a/funcytaskengine/transition_conditions/nsq.py
+++ b/funcytaskengine/transition_conditions/nsq.py
@@ -13,15 +13,18 @@ class NSQOnMessage(BaseTransitionCondition):
     def __init__(self, *args, **kwargs):
         pass
 
-    def is_met(self, message):
+    def is_met(self, messages):
         """
         Qualifies whenever any truthy message is received.
 
         :param message:
         :return: boolean
         """
-        if message:
-            return message.body
+        if messages:
+            logging.debug({
+                'messages': messages
+            })
+            return messages
 
 
 class NSQOnJSONMessage(BaseTransitionCondition):

--- a/funcytaskengine/transition_conditions/nsq.py
+++ b/funcytaskengine/transition_conditions/nsq.py
@@ -1,4 +1,11 @@
+import json
+
+import logging
+
 from .base import BaseTransitionCondition
+
+
+logger = logging.getLogger(__name__)
 
 
 class NSQOnMessage(BaseTransitionCondition):
@@ -15,3 +22,16 @@ class NSQOnMessage(BaseTransitionCondition):
         """
         if message:
             return message.body
+
+
+class NSQOnJSONMessage(BaseTransitionCondition):
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def is_met(self, message):
+        message_body = json.loads(NSQOnMessage().is_met(message))
+        logging.debug({
+            'message_body': message_body
+        })
+        return message_body

--- a/funcytaskengine/transition_conditions/nsq.py
+++ b/funcytaskengine/transition_conditions/nsq.py
@@ -14,4 +14,4 @@ class NSQOnMessage(BaseTransitionCondition):
         :return: boolean
         """
         if message:
-            return True
+            return message.body

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ parameterized==0.6.1
 requests==2.13.0
 gnsq==0.3.3
 psycopg2==2.7.1
+unittest-xml-reporting==2.1.0
 
 mock==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -6,4 +6,5 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     # install_requires=INSTALL_REQUIRES,
+    scripts=['bin/funcy-task-engine.py']
 )

--- a/tests/funcy/timeout-single-message-streamed.yml
+++ b/tests/funcy/timeout-single-message-streamed.yml
@@ -1,0 +1,57 @@
+---
+max_timeout: 10000000
+name: test_timeout_single_message_streamed
+version: "1"
+events:
+
+  - name: create_nsq_topic
+    initiator:
+      method: post
+      type: http.HTTPInitiator
+      url: "http://localhost:4151/topic/create?topic=functional_test"
+
+  - name: empty_nsq_topic
+    initiator:
+      method: post
+      type: http.HTTPInitiator
+      url: "http://localhost:4151/topic/empty?topic=functional_test"
+
+  - name: empty_nsq_channel
+    initiator:
+      method: post
+      type: http.HTTPInitiator
+      url: "http://localhost:4151/topic/empty?topic=functional_test&channel=test"
+
+  - name: publish_message
+    initiator:
+      type: nsq.NSQPublisherInitiator
+      message: >
+          {
+                "event_id": "e571faea-b053-11e6-8f30-22000bdcc52a",
+                "video_id": "523a4a96e79548b89a000003",
+                "test": "$UUID_STRING_1"
+          }
+      nsqd_address: localhost
+      topic: "functional_test"
+
+  - name: pull_single_message
+    event_fulfillment_strategy:
+      type: nsq.NSQStreamingSingleMessageFulfillment
+      topic: "functional_test"
+      channel: test
+      address: "localhost:4150"
+    transition_conditions:
+        - type: nsq.NSQOnMessage
+
+  - name: valid_json
+    event_fulfillment_strategy:
+      type: results.FromEventNameFulfillment
+      event_name: pull_single_message
+    transition_conditions:
+      - type: assertions.ParseJSON
+        value_property: body
+      - type: assertions.HasKeys
+        keys:
+          - event_id
+          - video_id
+          - test

--- a/tests/funcy/uuid-nsq-postgres.yml
+++ b/tests/funcy/uuid-nsq-postgres.yml
@@ -1,6 +1,6 @@
 ---
 max_timeout: 100000000000
-name: ENVVAR_UUID_nsq_postgres_assertions
+name: UUID_nsq_postgres_assertions
 version: "1"
 events:
 


### PR DESCRIPTION
I was making a real functional test and an event need to reference the return value of another event.  Since this capacity doesn't exist one option would have been to shove a whole bunch of logic into `transition_conditions` but I thought referencing a previous events return value would be cleaner, and more useful, in the long run.

In coming back to this after a couple weeks, there is crazy spaghetti coupling going on.  I'm not sure what we should be optimizing for, because even though each module is a tiny little class, to understand how it fits together and the execution order is pretty nuts